### PR TITLE
Rewrite Makefile

### DIFF
--- a/projects/hsuweic/dominion/Makefile
+++ b/projects/hsuweic/dominion/Makefile
@@ -29,48 +29,31 @@ runtests: testDrawCard
 	gcov dominion.c >> unittestresult.out
 	cat dominion.c.gcov >> unittestresult.out
 
-unittestresult: unittest1.c unittest2.c unittest3.c unittest4.c cardtest1.c cardtest2.c cardtest3.c cardtest4.c
-	echo "Result for running unit tests:" > unittestresults.out
-	echo "unittest1.c:" >> unittestresults.out
-	gcc test_helper.c rngs.c dominion.c unittest1.c -lm -o unittest1 $(CFLAGS)
-	./unittest1 >> unittestresults.out
-	gcov dominion.c >> unittestresults.out
+test_helper.o: test_helper.h test_helper.c
+	gcc -c test_helper.c -g  $(CFLAGS)
 
-	echo "unittest2.c:" >> unittestresults.out
-	gcc test_helper.c rngs.c dominion.c unittest2.c -lm -o unittest2 $(CFLAGS)
-	./unittest2 >> unittestresults.out
-	gcov dominion.c >> unittestresults.out
-
-	echo "unittest3.c:" >> unittestresults.out
-	gcc test_helper.c rngs.c dominion.c unittest3.c -lm -o unittest3 $(CFLAGS)
-	./unittest3 >> unittestresults.out
-	gcov dominion.c >> unittestresults.out
-
-	echo "unittest4.c:" >> unittestresults.out
-	gcc  test_helper.c rngs.c dominion.c unittest4.c -lm -o unittest4 $(CFLAGS)
-	./unittest4 >> unittestresults.out
-	gcov dominion.c >> unittestresults.out
+unittest1: unittest1.c dominion.o test_helper.o rngs.o
+	gcc -o unittest1 unittest1.c -g dominion.o test_helper.o rngs.o $(CFLAGS)
 	
-	echo "cardtest1.c:" >> unittestresults.out
-	gcc test_helper.c rngs.c dominion.c cardtest1.c -lm -o cardtest1 $(CFLAGS)
-	./cardtest1 >> unittestresults.out
-	gcov dominion.c >> unittestresults.out
-
-	echo "cardtest2.c:" >> unittestresults.out
-	gcc test_helper.c rngs.c dominion.c cardtest2.c -lm -o cardtest2 $(CFLAGS)
-	./cardtest2 >> unittestresults.out
-	gcov dominion.c >> unittestresults.out
-
-	echo "cardtest3.c:" >> unittestresults.out
-	gcc test_helper.c rngs.c dominion.c cardtest3.c -lm -o cardtest3 $(CFLAGS)
-	./cardtest3 >> unittestresults.out
-	gcov dominion.c >> unittestresults.out
-
-	echo "cardtest4.c:" >> unittestresults.out
-	gcc  test_helper.c rngs.c dominion.c cardtest4.c -lm -o cardtest4 $(CFLAGS)
-	./cardtest4 >> unittestresults.out
-	gcov dominion.c >> unittestresults.out
-
+unittest2: unittest2.c dominion.o test_helper.o rngs.o
+	gcc -o unittest2 unittest2.c -g dominion.o test_helper.o rngs.o $(CFLAGS)	
+	
+unittest3: unittest3.c dominion.o test_helper.o rngs.o
+	gcc -o unittest3 unittest3.c -g dominion.o test_helper.o rngs.o $(CFLAGS)
+	
+unittest4: unittest4.c dominion.o test_helper.o rngs.o
+	gcc -o unittest4 unittest4.c -g dominion.o test_helper.o rngs.o $(CFLAGS)
+	
+cardtest1: cardtest1.c dominion.o test_helper.o rngs.o
+	gcc -o cardtest1 cardtest1.c -g dominion.o test_helper.o rngs.o $(CFLAGS)
+	
+cardtest2: cardtest2.c dominion.o test_helper.o rngs.o
+	gcc -o cardtest2 cardtest2.c -g dominion.o test_helper.o rngs.o $(CFLAGS)
+	
+	
+unittestresults: unittest1 unittest2 unittest3 unittest4
+	@chmod +x unittest_result_generator
+	@./unittest_result_generator
 
 player: player.c interface.o
 	gcc -o player player.c -g  dominion.o rngs.o interface.o $(CFLAGS)
@@ -78,4 +61,4 @@ player: player.c interface.o
 all: playdom player 
 
 clean:
-	rm -f *.o playdom.exe playdom player player.exe unittest1 unittest2 unittest3 cardtest4 cardtest1 cardtest2 cardtest3 unittest4 *.gcov *.gcda *.gcno *.so *.out testDrawCard testDrawCard.exe
+	rm -f *.o playdom.exe playdom player player.exe test_helper unittest1 unittest2 unittest3 cardtest4 cardtest1 cardtest2 cardtest3 unittest4 *.gcov *.gcda *.gcno *.so *.out testDrawCard testDrawCard.exe

--- a/projects/hsuweic/dominion/unittest4.c
+++ b/projects/hsuweic/dominion/unittest4.c
@@ -1,8 +1,7 @@
-/* Testing 
- * 1. 
- * 2. 
- * 3. 
- * 4. 
+/* Testing FullDeck
+ * 1. Check the default number of Cooper / Silver in the deck
+ * 2. Check the numbe of double coopers in the deck
+ * 3. Check if CUTPURSE is in the deck when we start the game (It should not be there)
  */
 #include "dominion.h"
 #include "dominion_helpers.h"
@@ -11,9 +10,27 @@
 #include <stdbool.h>
 #include "test_helper.h"
 #include "rngs.h"
+#define SEED 10
 
 void testFullDeckCount()
 {
+  int numPlayer = 2;
+  int k[10] = {ADVENTURER, GARDENS, EMBARGO, VILLAGE, MINION, MINE, CUTPURSE, SEA_HAG, TRIBUTE, SMITHY};
+  struct gameState *G;
+  bool test_result = true;
+  int handCard = 0;
+
+  G = newGame();
+  initializeGame(numPlayer, k, SEED, G);
+
+  testEqual("No card: should return 0.", 0, fullDeckCount(handCard, CUTPURSE, G), &test_result);
+  testEqual("Defaul SILVER: should return 0.", 0, fullDeckCount(handCard, SILVER, G), &test_result);
+  testEqual("Defaul COPPER: should return 0.", 7, fullDeckCount(handCard, COPPER, G), &test_result);
+
+  memcpy(G->discard[0], G->deck[0], sizeof(G->deck[0]));
+  G->discardCount[0] = 10;
+  testEqual("Double COPPER size: should return 14.", 14, fullDeckCount(handCard, COPPER, G), &test_result);
+  testResult(test_result);
 
 }
 

--- a/projects/hsuweic/dominion/unittest_result_generator
+++ b/projects/hsuweic/dominion/unittest_result_generator
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+echo "============ UNIT TEST 1 ============" >> unittestresults.out
+./unittest1 >> unittestresults.out
+var=$(gcov dominion.c --function-summaries | grep -n updateCoins | cut -f1 -d:)
+((var++))
+gcov dominion.c --function-summaries | head -n$(echo $var) | tail -n2 >> unittestresults.out
+gcov dominion.c >> unittestresults.out
+echo -e "\n\n" >> unittestresults.out
+
+echo "============ UNIT TEST 2 ============" >> unittestresults.out
+./unittest2 >> unittestresults.out
+var=$(gcov dominion.c --function-summaries | grep -n shuffle | cut -f1 -d:)
+((var++))
+gcov dominion.c --function-summaries | head -n$(echo $var) | tail -n2 >> unittestresults.out
+gcov dominion.c >> unittestresults.out
+echo -e "\n\n" >> unittestresults.out
+
+echo "============ UNIT TEST 3 ============" >> unittestresults.out
+./unittest3 >> unittestresults.out
+var=$(gcov dominion.c --function-summaries | grep -n newGame | cut -f1 -d:)
+((var++))
+gcov dominion.c --function-summaries | head -n$(echo $var) | tail -n2 >> unittestresults.out
+gcov dominion.c >> unittestresults.out
+echo -e "\n\n" >> unittestresults.out
+
+echo "============ UNIT TEST 4 ============" >> unittestresults.out
+./unittest4 >> unittestresults.out
+var=$(gcov dominion.c --function-summaries | grep -n fullDeckCount | cut -f1 -d:)
+((var++))
+gcov dominion.c --function-summaries | head -n$(echo $var) | tail -n2 >> unittestresults.out
+gcov dominion.c >> unittestresults.out
+echo -e "\n\n" >> unittestresults.out


### PR DESCRIPTION
- Implemented the Makefile combined with bash
- Separated the `unittest` and `cardtest`
- Split the output in **testresult.out** file for only representing tested function and file.

:hammer: 
## TODO
- 1 Implement cardtest1, cardtest2, cardtest3 and cardtest4.
- 2 Add cardtest object into the Makefile
- 3 Record the processes: **How to simplify the code**, **How to separate the logic** in `Testing effort` session.
- 4 Record bugs found in cardtest.c in `Bugs` session.
- 5 Record the **coverage**, **implication** and **design** in `Unit Testing` session.